### PR TITLE
Update add new TextStyle attributes

### DIFF
--- a/pagecontent/schema/pagecontent.xsd
+++ b/pagecontent/schema/pagecontent.xsd
@@ -38,8 +38,7 @@
 			</element>
             <element name="UserDefined" type="pc:UserDefinedType"
 				minOccurs="0" maxOccurs="1">
-			</element>
-
+			</element>
             <element name="MetadataItem" type="pc:MetadataItemType" minOccurs="0" maxOccurs="unbounded"></element>
         </sequence>
 		<attribute name="externalRef" type="string" use="optional">
@@ -100,8 +99,7 @@
 					Reference to external model / ontology / schema
 				</documentation>
 			</annotation>
-		</attribute>
-
+		</attribute>
         <attribute name="externalId" type="string" use="optional">
 			<annotation>
 				<documentation>E.g. an RDF resource identifier (to be used as subject or object of an RDF triple)</documentation>
@@ -114,8 +112,7 @@
 			</annotation>
 		</attribute>
         <attribute name="comments" type="string" use="optional">
-		</attribute>
-
+		</attribute>
 	</complexType>
 	<complexType name="LabelType">
         <annotation>
@@ -2158,15 +2155,29 @@ It does not contain pagenumber (if not part of running title), marginals, signat
     	<attribute name="bold" type="boolean"></attribute>
     	<attribute name="italic" type="boolean"></attribute>
     	<attribute name="underlined" type="boolean"></attribute>
-    	<attribute name="double-underlined" type="boolean"></attribute>
+        <attribute name="doubleUnderlined" type="boolean"></attribute>
     	<attribute name="subscript" type="boolean"></attribute>
     	<attribute name="superscript" type="boolean"></attribute>
     	<attribute name="strikethrough" type="boolean"></attribute>
         <attribute name="smallCaps" type="boolean"></attribute>
         <attribute name="letterSpaced" type="boolean"></attribute>
-    	<attribute name="antiqua" type="boolean"></attribute>
-    	<attribute name="fracturswitch" type="boolean"></attribute>
-    	
+        <attribute name="antiqua" type="boolean">
+            <annotation>
+                <documentation>
+                    This element is typeset in an Antiqua typeface and not a
+                    blackletter typeface.
+                </documentation>
+            </annotation>
+        </attribute>
+        <attribute name="fracturSwitch" type="boolean">
+            <annotation>
+                <documentation>
+                    This element is typeset in blackletter typeface and not an
+                    Antiqua typeset or in a different blackletter typeface than
+                    the previous element.
+                </documentation>
+            </annotation>
+        </attribute>
     </complexType>
 
     <complexType name="RegionType" abstract="true">

--- a/pagecontent/schema/pagecontent.xsd
+++ b/pagecontent/schema/pagecontent.xsd
@@ -2161,23 +2161,6 @@ It does not contain pagenumber (if not part of running title), marginals, signat
     	<attribute name="strikethrough" type="boolean"></attribute>
         <attribute name="smallCaps" type="boolean"></attribute>
         <attribute name="letterSpaced" type="boolean"></attribute>
-        <attribute name="antiqua" type="boolean">
-            <annotation>
-                <documentation>
-                    This element is typeset in an Antiqua typeface and not a
-                    blackletter typeface.
-                </documentation>
-            </annotation>
-        </attribute>
-        <attribute name="fracturSwitch" type="boolean">
-            <annotation>
-                <documentation>
-                    This element is typeset in blackletter typeface and not an
-                    Antiqua typeset or in a different blackletter typeface than
-                    the previous element.
-                </documentation>
-            </annotation>
-        </attribute>
     </complexType>
 
     <complexType name="RegionType" abstract="true">

--- a/pagecontent/schema/pagecontent.xsd
+++ b/pagecontent/schema/pagecontent.xsd
@@ -38,7 +38,8 @@
 			</element>
             <element name="UserDefined" type="pc:UserDefinedType"
 				minOccurs="0" maxOccurs="1">
-			</element>
+			</element>
+
             <element name="MetadataItem" type="pc:MetadataItemType" minOccurs="0" maxOccurs="unbounded"></element>
         </sequence>
 		<attribute name="externalRef" type="string" use="optional">
@@ -99,7 +100,8 @@
 					Reference to external model / ontology / schema
 				</documentation>
 			</annotation>
-		</attribute>
+		</attribute>
+
         <attribute name="externalId" type="string" use="optional">
 			<annotation>
 				<documentation>E.g. an RDF resource identifier (to be used as subject or object of an RDF triple)</documentation>
@@ -112,7 +114,8 @@
 			</annotation>
 		</attribute>
         <attribute name="comments" type="string" use="optional">
-		</attribute>
+		</attribute>
+
 	</complexType>
 	<complexType name="LabelType">
         <annotation>
@@ -2155,11 +2158,15 @@ It does not contain pagenumber (if not part of running title), marginals, signat
     	<attribute name="bold" type="boolean"></attribute>
     	<attribute name="italic" type="boolean"></attribute>
     	<attribute name="underlined" type="boolean"></attribute>
+    	<attribute name="double-underlined" type="boolean"></attribute>
     	<attribute name="subscript" type="boolean"></attribute>
     	<attribute name="superscript" type="boolean"></attribute>
     	<attribute name="strikethrough" type="boolean"></attribute>
         <attribute name="smallCaps" type="boolean"></attribute>
         <attribute name="letterSpaced" type="boolean"></attribute>
+    	<attribute name="antiqua" type="boolean"></attribute>
+    	<attribute name="fracturswitch" type="boolean"></attribute>
+    	
     </complexType>
 
     <complexType name="RegionType" abstract="true">


### PR DESCRIPTION
add the new attributes:
- double-underlined
- antiqua
- fracturswitch

**Antiqua** stands for the change of the main font of the text from Fraktur to Antiqua. This can involve passages, individual words or parts of words. Antiqua does not stand for a specific font.

**Fracturswitch** stands for the change of the main font of the text from Fraktur to Fraktur. A fracturswitch is a special type of highlighting. Since, for example, there is no bold cut in the Fraktur fonts, a different Fraktur font (e.g. Schwabacher) was used to make a bold typeface. This can concern passages, single words as well as word parts.